### PR TITLE
Specify required_ruby_version in gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 rvm:
+  - 2.2.8
   - 2.3.5
   - 2.4.2
 gemfile:

--- a/gretel-jsonld.gemspec
+++ b/gretel-jsonld.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Gretel extension for supporting JSON-LD breadcrumbs"
   s.description = "gretel-jsonld enables gretel gem to handle JSON-LD based breadcrumbs."
   s.license     = "MIT"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.files = Dir["CHANGELOG.md", "lib/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
gretel-jsonld uses Hash string key syntax, introduced in Ruby 2.2.
So we should specify a required ruby version in the gem.

This PR fixes `.gemspec` to specify the required version.