### PR TITLE
 Use JSONLD as module name instead of Jsonld

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gretel::Jsonld
+# Gretel::JSONLD
 Short description and motivation.
 
 ## Usage

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ require "rdoc/task"
 
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = "rdoc"
-  rdoc.title    = "Gretel::Jsonld"
+  rdoc.title    = "Gretel::JSONLD"
   rdoc.options << "--line-numbers"
   rdoc.rdoc_files.include("README.md")
   rdoc.rdoc_files.include("lib/**/*.rb")

--- a/gretel-jsonld.gemspec
+++ b/gretel-jsonld.gemspec
@@ -6,7 +6,7 @@ require "gretel/jsonld/version"
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "gretel-jsonld"
-  s.version     = Gretel::Jsonld::VERSION
+  s.version     = Gretel::JSONLD::VERSION
   s.authors     = ["yasaichi"]
   s.email       = ["yasaichi@users.noreply.github.com"]
   s.homepage    = "https://github.com/yasaichi/gretel-jsonld"

--- a/lib/gretel/jsonld/breadcrumb/list.rb
+++ b/lib/gretel/jsonld/breadcrumb/list.rb
@@ -6,7 +6,7 @@ require "active_support/json/encoding"
 require "gretel/jsonld/breadcrumb/list_item"
 
 module Gretel
-  module Jsonld
+  module JSONLD
     module Breadcrumb
       class List
         def initialize(link_collection)
@@ -30,7 +30,7 @@ module Gretel
 
         def item_list_element
           @link_collection.map.with_index(1) do |link, index|
-            ::Gretel::Jsonld::Breadcrumb::ListItem.new(
+            ::Gretel::JSONLD::Breadcrumb::ListItem.new(
               id: link.url,
               name: link.text,
               position: index,

--- a/lib/gretel/jsonld/breadcrumb/list_item.rb
+++ b/lib/gretel/jsonld/breadcrumb/list_item.rb
@@ -5,7 +5,7 @@ require "active_support"
 require "active_support/json/encoding"
 
 module Gretel
-  module Jsonld
+  module JSONLD
     module Breadcrumb
       class ListItem
         def initialize(id:, name:, position:)

--- a/lib/gretel/jsonld/railtie.rb
+++ b/lib/gretel/jsonld/railtie.rb
@@ -5,7 +5,7 @@ require "active_support/lazy_load_hooks"
 require "rails/railtie"
 
 module Gretel
-  module Jsonld
+  module JSONLD
     class Railtie < ::Rails::Railtie
       initializer "gretel.jsonld" do
         ::ActiveSupport.on_load(:action_view) do

--- a/lib/gretel/jsonld/renderer.rb
+++ b/lib/gretel/jsonld/renderer.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/string/output_safety"
 require "gretel/jsonld/breadcrumb/list"
 
 module Gretel
-  module Jsonld
+  module JSONLD
     class Renderer
       def initialize(view_context)
         @view_context = view_context
@@ -17,7 +17,7 @@ module Gretel
 
         @view_context.content_tag(
           :script,
-          JSON.generate(::Gretel::Jsonld::Breadcrumb::List.new(link_collection)).html_safe,
+          JSON.generate(::Gretel::JSONLD::Breadcrumb::List.new(link_collection)).html_safe,
           type: "application/ld+json",
         )
       end

--- a/lib/gretel/jsonld/version.rb
+++ b/lib/gretel/jsonld/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Gretel
-  module Jsonld
+  module JSONLD
     VERSION = "0.1.1"
   end
 end

--- a/lib/gretel/jsonld/view_helpers.rb
+++ b/lib/gretel/jsonld/view_helpers.rb
@@ -5,7 +5,7 @@ require "gretel"
 require "gretel/jsonld/renderer"
 
 module Gretel
-  module Jsonld
+  module JSONLD
     module ViewHelpers
       def jsonld_breadcrumbs(options = {})
         gretel_jsonld_renderer.render(breadcrumbs(options))
@@ -14,10 +14,10 @@ module Gretel
       private
 
       def gretel_jsonld_renderer
-        @_gretel_jsonld_renderer ||= ::Gretel::Jsonld::Renderer.new(self)
+        @_gretel_jsonld_renderer ||= ::Gretel::JSONLD::Renderer.new(self)
       end
     end
   end
 end
 
-ActionView::Base.include(Gretel::Jsonld::ViewHelpers)
+ActionView::Base.include(Gretel::JSONLD::ViewHelpers)

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Gretel::Jsonld::ViewHelpers, type: :helper do
+RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
   describe "#jsonld_breadcrumbs" do
     subject { helper.jsonld_breadcrumbs(link_current_to_request_path: false) }
 


### PR DESCRIPTION
As you know, JSON-LD is an abbreviation for "JSON for Linking Data", so it seems strange to use `Jsonld` to refer the abbreviation.

This PR renames `Jsonld` to `JSONLD`.