### PR TITLE
Prepare CI for main branch rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub Actions does not update branch filters when a branch is renamed. Include both master and main before the rename so CI continues to run throughout the transition.