### PR TITLE
Configure Renovate update policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "Limit GitHub Action updates to explicitly enabled types",
+      "enabled": false,
+      "matchDepTypes": ["action"],
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Enable major GitHub Action updates",
+      "enabled": true,
+      "matchDepTypes": ["action"],
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- enable Renovate with its recommended configuration
- keep GitHub Actions pinned to commit digests while proposing only major Action updates
- wait seven days before proposing newly released dependency versions

## Why

This enables dependency automation without creating routine GitHub Action pull requests for digest or same-major updates. Major Action changes remain visible for review, while commit pinning preserves reproducible workflow dependencies.

## Validation

- `jq empty renovate.json`
- `git diff --check origin/main...HEAD`