### PR TITLE
Automate gem releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Push gem to RubyGems
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify release commit
+        run: |
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} must point to a commit on main"
+            exit 1
+          fi
+
+      - uses: ruby/setup-ruby@a30dfa457ad68707b8b910ac3a244714b61c0626 # v1.320.0
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+
+      - name: Verify release tag
+        run: |
+          version="$(bundle exec ruby -Ilib -r gretel/jsonld/version -e 'puts Gretel::JSONLD::VERSION')"
+          if [ "v${version}" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} must match gem version v${version}"
+            exit 1
+          fi
+
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0


### PR DESCRIPTION
## Summary

- Publish the gem when a GitHub Release is published
- Authenticate to RubyGems with Trusted Publishing through the `release` environment
- Require the release tag to match `v<VERSION>` and point to a commit on `main`

## Why

Releasing currently requires a manual RubyGems push. Trusted Publishing replaces long-lived credentials with a short-lived OIDC credential while keeping GitHub Release publication as the explicit release action.

## Verification

- `bundle exec rake build`
- Parsed `.github/workflows/release.yml` as YAML
- Simulated tag validation with `v0.2.0`
- Verified that a `main` commit is accepted and a side-branch commit is rejected
