### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [0.3.0](https://github.com/yasaichi/gretel-jsonld/releases/tag/v0.3.0) (July 22, 2026)
+* [Test against Rails 6 through 8](https://github.com/yasaichi/gretel-jsonld/pull/18)
+* [Drop support for Ruby 2.4 and earlier](https://github.com/yasaichi/gretel-jsonld/pull/16)
+
 ## [0.2.0](https://github.com/yasaichi/gretel-jsonld/releases/tag/v0.2.0) (November 25, 2017)
 * [Write README](https://github.com/yasaichi/gretel-jsonld/pull/7)
 * [Use `JSONLD` as module name instead of `Jsonld`](https://github.com/yasaichi/gretel-jsonld/pull/6)

--- a/lib/gretel/jsonld/version.rb
+++ b/lib/gretel/jsonld/version.rb
@@ -2,6 +2,6 @@
 
 module Gretel
   module JSONLD
-    VERSION = "0.2.0".freeze
+    VERSION = "0.3.0".freeze
   end
 end


### PR DESCRIPTION
## Summary

- Bump the gem version from 0.2.0 to 0.3.0.
- Add the v0.3.0 changelog entry for Rails 6–8 compatibility coverage.
- Document that Ruby 2.4 and earlier are no longer supported.

## Why

The gem version and user-facing compatibility notes need to reflect the changes made since v0.2.0 before publishing the next release.

## Impact

v0.3.0 requires Ruby 2.5 or later and records compatibility coverage for Rails 6 through 8.

## Verification

- `git diff --check`
- `direnv exec . bundle exec rake` could not start because the local Ruby 2.5 environment was missing dependencies.
- `direnv exec . bundle install` then failed while building Nokogiri 1.6.6.4 because `/usr/include/iconv.h` was unavailable.