### PR TITLE
Migrate to RuboCop Rails Omakase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,4 @@ gemfiles/*.lock
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-# RuboCop cache
-.rubocop-http*
-
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
-inherit_from:
-  - https://raw.githubusercontent.com/rails/rails/master/.rubocop.yml
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
 
 AllCops:
   Exclude:
     - gretel-jsonld.gemspec
     - spec/dummy/**/*
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Style/Documentation:

--- a/gretel-jsonld.gemspec
+++ b/gretel-jsonld.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "reek"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "rubocop"
-  s.add_development_dependency "rubocop-performance"
+  s.add_development_dependency "rubocop-rails-omakase"
   s.add_development_dependency "simplecov"
 end

--- a/lib/gretel/jsonld/breadcrumb/list.rb
+++ b/lib/gretel/jsonld/breadcrumb/list.rb
@@ -18,7 +18,7 @@ module Gretel
           {
             "@context": "http://schema.org",
             "@type": "BreadcrumbList",
-            itemListElement: item_list_element,
+            itemListElement: item_list_element
           }.as_json(options)
         end
 

--- a/lib/gretel/jsonld/breadcrumb/list_item.rb
+++ b/lib/gretel/jsonld/breadcrumb/list_item.rb
@@ -21,7 +21,7 @@ module Gretel
             position: @position,
             item: {
               "@id": @id,
-              name: @name,
+              name: @name
             }
           }.as_json(options)
         end

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,4 +1,0 @@
-linter:
-  rubocop:
-    gems:
-      - "rubocop-performance"

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
         JSON.generate(
           "@context": "http://schema.org",
           "@type": "BreadcrumbList",
-          itemListElement: [{
+          itemListElement: [ {
             "@type": "ListItem",
             position: 1,
             item: {
@@ -34,7 +34,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
               "@id": "http://test.host/about",
               name: "About"
             }
-          }]
+          } ]
         )
       end
 


### PR DESCRIPTION
## Summary

- replace the remotely inherited Rails RuboCop configuration with `rubocop-rails-omakase`
- let the Omakase gem provide RuboCop and its required extensions
- remove the legacy SideCI plugin configuration and apply the Omakase formatting rules

## Why

The RuboCop configuration inherited from the Rails `master` branch now loads plugins that this project does not declare. Because that remote configuration changes independently of this repository, the lint setup can break without a local dependency change.

Using `rubocop-rails-omakase` keeps the ruleset and its required plugins together as versioned Bundler dependencies.

## Validation

- `mise x ruby@3.4.10 -- bundle exec rubocop -C false` — 17 files inspected, no offenses
- Ruby 2.5 dependency resolution with the Rails 5 appraisal — succeeded with compatible Omakase and RuboCop versions