### PR TITLE
Load Railtie only when available

### DIFF
--- a/gretel-jsonld.gemspec
+++ b/gretel-jsonld.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 5.0"
   s.add_dependency "actionview", ">= 5.0"
   s.add_dependency "gretel", ">= 3.0"
-  s.add_dependency "railties", ">= 5.0"
 
   s.add_development_dependency "appraisal"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "railties", ">= 5.0"
   s.add_development_dependency "reek"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop-rails-omakase"
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "sqlite3"
 end

--- a/lib/gretel/jsonld.rb
+++ b/lib/gretel/jsonld.rb
@@ -3,7 +3,7 @@
 require "action_view"
 require "gretel/jsonld/version"
 
-if defined?(Rails)
+if defined?(Rails::Railtie)
   require "gretel/jsonld/railtie"
 else
   require "gretel/jsonld/view_helpers"

--- a/lib/gretel/jsonld/railtie.rb
+++ b/lib/gretel/jsonld/railtie.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/lazy_load_hooks"
-require "rails/railtie"
 require "gretel/jsonld/view_helpers"
 
 module Gretel


### PR DESCRIPTION
## Summary

- Load the gretel-jsonld Railtie only when `Rails::Railtie` is already available
- Stop requiring `rails/railtie` from the integration itself
- Keep Railties explicit for development and integration tests instead of declaring it as a runtime dependency

## Why

This follows up on [#21](https://github.com/yasaichi/gretel-jsonld/pull/21), which declared Railties as a runtime dependency because gretel-jsonld required it directly.

Rails extensions should register their Railtie when the host application has already loaded `Rails::Railtie`. Loading Railties from gretel-jsonld made the host application's boot dependency appear to be part of this gem's runtime ownership. The development dependency remains explicit because the dummy Rails application and integration tests use Railties directly.

Action View and Active Support remain runtime dependencies because gretel-jsonld uses them directly.

## Validation

- RSpec: 2 examples, 0 failures with Ruby 3.3 and Rails 6.1
- RuboCop: 18 files inspected, no offenses
- Verified the Railtie integration loads when `Rails::Railtie` is available
- Ran syntax checks and `git diff --check`
