### PR TITLE
Use URL form for breadcrumb items

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,26 +73,20 @@ This will generate the following breadcrumbs, marked up with JSON-LD (indented f
       {
         "@type": "ListItem",
         "position": 1,
-        "item": {
-          "@id": "/",
-          "name": "Home"
-        }
+        "name": "Home",
+        "item": "/"
       },
       {
         "@type": "ListItem",
         "position": 2,
-        "item": {
-          "@id": "/issues",
-          "name": "All issues"
-        }
+        "name": "All issues",
+        "item": "/issues"
       },
       {
         "@type": "ListItem",
         "position": 3,
-        "item": {
-          "@id": "/issues/46",
-          "name": "My Issue"
-        }
+        "name": "My Issue",
+        "item": "/issues/46"
       }
     ]
   }
@@ -107,7 +101,7 @@ You can pass `jsonld_breadcrumbs` the same options as `breadcrumbs`:
 <%= jsonld_breadcrumbs link_current_to_request_path: false %>
 ```
 
-For further information, please see [gretel's documentation](https://github.com/WilHall/gretel/blob/develop/README.md#options).
+For further information, please see [gretel's documentation](https://github.com/kzkn/gretel/blob/main/README.md#options).
 
 ## Supported versions
 

--- a/lib/gretel/jsonld/breadcrumb/list.rb
+++ b/lib/gretel/jsonld/breadcrumb/list.rb
@@ -24,9 +24,9 @@ module Gretel
         def item_list_element
           @link_collection.map.with_index(1) do |link, index|
             ::Gretel::JSONLD::Breadcrumb::ListItem.new(
-              id: link.url,
-              name: link.text,
               position: index,
+              title: link.text,
+              url: link.url,
             )
           end
         end

--- a/lib/gretel/jsonld/breadcrumb/list_item.rb
+++ b/lib/gretel/jsonld/breadcrumb/list_item.rb
@@ -6,20 +6,18 @@ module Gretel
   module JSONLD
     module Breadcrumb
       class ListItem
-        def initialize(id:, name:, position:)
-          @id = id
-          @name = name
+        def initialize(position:, title:, url:)
           @position = position
+          @title = title
+          @url = url
         end
 
         def to_json(*args)
           {
             "@type": "ListItem",
             position: @position,
-            item: {
-              "@id": @id,
-              name: @name
-            }
+            name: @title,
+            item: @url
           }.to_json(*args)
         end
       end

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -22,18 +22,14 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
           itemListElement: [ {
             "@type": "ListItem",
             position: 1,
-            item: {
-              "@id": "http://test.host/",
-              name: "Home"
-            }
+            name: "Home",
+            item: "http://test.host/"
           },
           {
             "@type": "ListItem",
             position: 2,
-            item: {
-              "@id": "http://test.host/about",
-              name: "About"
-            }
+            name: "About",
+            item: "http://test.host/about"
           } ]
         )
       end


### PR DESCRIPTION
## Summary

- serialize each breadcrumb `item` as a URL and keep `name` on the `ListItem`
- keep the private `ListItem` initializer focused on `title`, `url`, and `position` rather than JSON-LD property names
- update the README output example and replace the stale Gretel documentation link

## Why

Google supports two ways to represent a breadcrumb `item`: a URL, or a `Thing` whose `@id` specifies that URL. The existing `Thing` form is therefore valid and equivalent for Google Search. However, it nests `name` inside `item`, while the URL form keeps `name` directly on the `ListItem`.

Google also documents that the last breadcrumb may omit `item` entirely, in which case Google uses the containing page's URL. Its JSON-LD example represents earlier items as `name` plus a URL `item`, then removes only `item` from the last entry. Adopting that form now makes a future “do not link the current breadcrumb” option a simple omission instead of requiring the nested `Thing` structure to be reshaped. See the [Google Search Central `ListItem` definition](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb#list-item).

## Compatibility

The structured-data meaning is unchanged for Google Search, but the serialized JSON shape changes from:

```json
"item": {
  "@id": "/issues",
  "name": "All issues"
}
```

to:

```json
"name": "All issues",
"item": "/issues"
```

Consumers that compare or parse the exact output shape will therefore need to update. The Ruby initializer change is limited to the private breadcrumb serialization API.

## Verification

- `bundle exec rspec`
- `bundle exec rubocop`
