### PR TITLE
Revert "Use URL form for breadcrumb items"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,20 +73,26 @@ This will generate the following breadcrumbs, marked up with JSON-LD (indented f
       {
         "@type": "ListItem",
         "position": 1,
-        "name": "Home",
-        "item": "/"
+        "item": {
+          "@id": "/",
+          "name": "Home"
+        }
       },
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "All issues",
-        "item": "/issues"
+        "item": {
+          "@id": "/issues",
+          "name": "All issues"
+        }
       },
       {
         "@type": "ListItem",
         "position": 3,
-        "name": "My Issue",
-        "item": "/issues/46"
+        "item": {
+          "@id": "/issues/46",
+          "name": "My Issue"
+        }
       }
     ]
   }
@@ -101,7 +107,7 @@ You can pass `jsonld_breadcrumbs` the same options as `breadcrumbs`:
 <%= jsonld_breadcrumbs link_current_to_request_path: false %>
 ```
 
-For further information, please see [gretel's documentation](https://github.com/kzkn/gretel/blob/main/README.md#options).
+For further information, please see [gretel's documentation](https://github.com/WilHall/gretel/blob/develop/README.md#options).
 
 ## Supported versions
 

--- a/lib/gretel/jsonld/breadcrumb/list.rb
+++ b/lib/gretel/jsonld/breadcrumb/list.rb
@@ -24,9 +24,9 @@ module Gretel
         def item_list_element
           @link_collection.map.with_index(1) do |link, index|
             ::Gretel::JSONLD::Breadcrumb::ListItem.new(
+              id: link.url,
+              name: link.text,
               position: index,
-              title: link.text,
-              url: link.url,
             )
           end
         end

--- a/lib/gretel/jsonld/breadcrumb/list_item.rb
+++ b/lib/gretel/jsonld/breadcrumb/list_item.rb
@@ -6,18 +6,20 @@ module Gretel
   module JSONLD
     module Breadcrumb
       class ListItem
-        def initialize(position:, title:, url:)
+        def initialize(id:, name:, position:)
+          @id = id
+          @name = name
           @position = position
-          @title = title
-          @url = url
         end
 
         def to_json(*args)
           {
             "@type": "ListItem",
             position: @position,
-            name: @title,
-            item: @url
+            item: {
+              "@id": @id,
+              name: @name
+            }
           }.to_json(*args)
         end
       end

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -22,14 +22,18 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
           itemListElement: [ {
             "@type": "ListItem",
             position: 1,
-            name: "Home",
-            item: "http://test.host/"
+            item: {
+              "@id": "http://test.host/",
+              name: "Home"
+            }
           },
           {
             "@type": "ListItem",
             position: 2,
-            name: "About",
-            item: "http://test.host/about"
+            item: {
+              "@id": "http://test.host/about",
+              name: "About"
+            }
           } ]
         )
       end


### PR DESCRIPTION
## Summary

- revert #25 and restore the nested `Thing` representation for breadcrumb items
- restore the pre-#25 JSON-LD output shape and the corresponding private serializer interface

## Why

#25 changed each breadcrumb from an `item` containing `@id` and `name` to a URL-valued `item` with `name` on the `ListItem`. This was intended to make it easier to omit the current page's URL in a later change.

Google Search supports both representations and treats them equivalently. It also allows `item` to be omitted from the final breadcrumb and then uses the containing page's URL. However, that omission rule is a Google-specific interpretation, and whether the current breadcrumb is rendered as an HTML link does not change the identity of the page represented in JSON-LD.

Schema.org defines `ListItem#item` as a `Thing`, and its `BreadcrumbList` JSON-LD example uses the nested `@id` and `name` form. Keeping that representation avoids making the gem's general Schema.org output depend on a Google-specific fallback.

Although the two forms are semantically equivalent for Google Search, the serialized JSON shape is part of this gem's public output. Consumers that parse or compare the exact output would see #25 as a breaking change. Since the URL form is not needed to support the intended behavior, restoring the established output is the safer compatibility choice.

References:

- [Schema.org `BreadcrumbList`](https://schema.org/BreadcrumbList)
- [Google Search Central `ListItem` definition](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb#list-item)

## Compatibility

This restores the public JSON-LD shape used before #25. The Ruby initializer change is limited to the private breadcrumb serializer API.