### PR TITLE
Document effective Gretel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ rails generate gretel:install
 Next, define "crumbs" in `config/breadcrumbs.rb`:
 
 ```ruby
-# See also: https://github.com/lassebunk/gretel#more-examples
+# See also: https://github.com/kzkn/gretel#more-examples
 
 # Root crumb
 crumb :root do
@@ -101,13 +101,23 @@ This will generate the following breadcrumbs, marked up with JSON-LD (indented f
 
 ## Options
 
-You can pass `jsonld_breadcrumbs` the same options as `breadcrumbs`:
+You can pass `jsonld_breadcrumbs` the same options as `breadcrumbs`.
 
 ```erb
-<%= jsonld_breadcrumbs link_current_to_request_path: false %>
+<%= jsonld_breadcrumbs autoroot: false, link_current_to_request_path: false %>
 ```
 
-For further information, please see [gretel's documentation](https://github.com/WilHall/gretel/blob/develop/README.md#options).
+Options that change the breadcrumb collection also affect the JSON-LD output. The following options directly affect the output:
+
+Option                   | Description                                                                                                                 | Default
+------------------------ | --------------------------------------------------------------------------------------------------------------------------- | -------
+:autoroot                | Whether it should automatically add the `:root` crumb to the `BreadcrumbList` if no parent is given.                       | True
+:display_single_fragment | Whether it should output the `BreadcrumbList` if it includes only one item.                                                  | False
+:link_current_to_request_path | Whether the current crumb's `item.@id` in the `BreadcrumbList` should always use the current request path.                    | True
+
+Options concerned only with HTML presentation do not change the JSON-LD output. For example, `link_current` only controls whether the current crumb is rendered as an HTML link. The current crumb always includes `item.@id` in JSON-LD.
+
+For further information, please see [Gretel's documentation](https://github.com/kzkn/gretel#options).
 
 ## Supported versions
 

--- a/gretel-jsonld.gemspec
+++ b/gretel-jsonld.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gretel", ">= 3.0"
 
   s.add_development_dependency "appraisal"
+  s.add_development_dependency "nokogiri"
   s.add_development_dependency "railties", ">= 5.0"
   s.add_development_dependency "reek"
   s.add_development_dependency "rspec-rails"

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -4,41 +4,166 @@ require "rails_helper"
 
 RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
   describe "#jsonld_breadcrumbs" do
-    subject { helper.jsonld_breadcrumbs(link_current_to_request_path: false) }
+    subject do
+      raw_subject
+        .yield_self { |s| Nokogiri::HTML.fragment(s).at_css('script[type="application/ld+json"]') }
+        .yield_self { |e| JSON.parse(e.text, symbolize_names: true) }
+    end
+
+    let(:raw_subject) { helper.jsonld_breadcrumbs(link_current_to_request_path: false, **options) }
 
     context "when #breadcrumb is not called in advance" do
-      it { is_expected.to eq "" }
+      let(:options) { {} }
+      it { expect(raw_subject).to eq("") }
     end
 
     context "when #breadcrumb is called in advance" do
-      before do
-        helper.breadcrumb(:with_root)
-      end
-
-      let(:expectation) do
-        JSON.generate(
+      let(:full_list) do
+        {
           "@context": "http://schema.org",
           "@type": "BreadcrumbList",
-          itemListElement: [ {
-            "@type": "ListItem",
-            position: 1,
-            item: {
-              "@id": "http://test.host/",
-              name: "Home"
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              item: {
+                "@id": "http://test.host/",
+                name: "Home"
+              }
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              item: {
+                "@id": "http://test.host/about",
+                name: "About"
+              }
             }
-          },
-          {
-            "@type": "ListItem",
-            position: 2,
-            item: {
-              "@id": "http://test.host/about",
-              name: "About"
-            }
-          } ]
-        )
+          ]
+        }
       end
 
-      it { is_expected.to eq %(<script type="application/ld+json">#{expectation}</script>) }
+      before do
+        helper.breadcrumb(breadcrumb_key)
+      end
+
+      describe "autoroot option" do
+        let(:options) { { autoroot: autoroot, display_single_fragment: true } }
+        let(:breadcrumb_key) { :with_root }
+
+        context "when set to true" do
+          let(:autoroot) { true }
+          it { is_expected.to eq(full_list) }
+        end
+
+        context "when set to false" do
+          let(:autoroot) { false }
+          let(:expectation) do
+            {
+              "@context": "http://schema.org",
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  item: {
+                    "@id": "http://test.host/about",
+                    name: "About"
+                  }
+                }
+              ]
+            }
+          end
+
+          it { is_expected.to eq(expectation) }
+        end
+      end
+
+      describe "display_single_fragment option" do
+        let(:options) { { display_single_fragment: display_single_fragment } }
+        let(:breadcrumb_key) { :root }
+
+        context "when set to false" do
+          let(:display_single_fragment) { false }
+          it { expect(raw_subject).to eq("") }
+        end
+
+        context "when set to true" do
+          let(:display_single_fragment) { true }
+          let(:expectation) do
+            {
+              "@context": "http://schema.org",
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  item: {
+                    "@id": "http://test.host/",
+                    name: "Home"
+                  }
+                }
+              ]
+            }
+          end
+
+          it { is_expected.to eq(expectation) }
+        end
+      end
+
+      describe "link_current_to_request_path option" do
+        let(:options) { { link_current_to_request_path: link_current_to_request_path } }
+        let(:breadcrumb_key) { :with_root }
+
+        before do
+          allow(helper.request).to receive(:fullpath).and_return("/requested")
+        end
+
+        context "when set to false" do
+          let(:link_current_to_request_path) { false }
+          it { is_expected.to eq(full_list) }
+        end
+
+        context "when set to true" do
+          let(:link_current_to_request_path) { true }
+
+          # TODO: Convert this relative request path to an absolute URL. Google reports
+          # it as a non-critical `Invalid URL in field "id"` issue.
+          let(:expectation) do
+            {
+              "@context": "http://schema.org",
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  item: {
+                    "@id": "http://test.host/",
+                    name: "Home"
+                  }
+                },
+                {
+                  "@type": "ListItem",
+                  position: 2,
+                  item: {
+                    "@id": "/requested",
+                    name: "About"
+                  }
+                }
+              ]
+            }
+          end
+
+          it { is_expected.to eq(expectation) }
+        end
+      end
+
+      describe "the other options" do
+        let(:options) { { link_current: true, semantic: true, style: :bootstrap } }
+        let(:breadcrumb_key) { :with_root }
+
+        it { is_expected.to eq(full_list) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- document the Gretel options that change the generated `BreadcrumbList`
- distinguish collection-changing options from options that only affect HTML rendering
- parse the generated JSON-LD with Nokogiri and cover each relevant option in both states
- update the Gretel documentation links to the current repository

## Why

`jsonld_breadcrumbs` forwards its options to Gretel's `breadcrumbs` helper, but the documentation did not explain which options affect the public JSON-LD output. The existing spec also forced `link_current_to_request_path: false`, so it did not describe the behavior of the other collection-changing options or clearly separate them from HTML-only presentation options.

This made the output contract difficult to understand and left future Gretel changes able to alter the generated JSON-LD without a focused regression failure. This PR keeps the existing output format and behavior intact while documenting and testing the effective options: `autoroot`, `display_single_fragment`, and `link_current_to_request_path`.

The current relative `item.@id` produced when `link_current_to_request_path: true` is deliberately captured as existing behavior. A TODO records that Google's Rich Results Test reports it as a non-critical `Invalid URL in field "id"` issue; changing that output should be handled separately.

Nokogiri is added as a development dependency so the spec can extract and compare the JSON-LD payload without coupling expectations to the surrounding `script` markup.

## Checks

- `mise exec ruby@4.0.6 -- bundle exec rspec spec/lib/gretel/jsonld/view_helpers_spec.rb`
- `mise exec ruby@4.0.6 -- bundle exec rubocop --cache false spec/lib/gretel/jsonld/view_helpers_spec.rb`