### PR TITLE
Generate valid breadcrumb URLs (breaking internal API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Finally, specify a current breadcrumb in each view:
 <% breadcrumb :issue, @issue %>
 ```
 
-This will generate the following breadcrumbs, marked up with JSON-LD (indented for readability):
+For a request to `https://example.com/issues/46`, this will generate the
+following JSON-LD (indented for readability):
 
 ```html
 <script type="application/ld+json">
@@ -74,7 +75,7 @@ This will generate the following breadcrumbs, marked up with JSON-LD (indented f
         "@type": "ListItem",
         "position": 1,
         "item": {
-          "@id": "/",
+          "@id": "https://example.com/",
           "name": "Home"
         }
       },
@@ -82,7 +83,7 @@ This will generate the following breadcrumbs, marked up with JSON-LD (indented f
         "@type": "ListItem",
         "position": 2,
         "item": {
-          "@id": "/issues",
+          "@id": "https://example.com/issues",
           "name": "All issues"
         }
       },
@@ -90,7 +91,7 @@ This will generate the following breadcrumbs, marked up with JSON-LD (indented f
         "@type": "ListItem",
         "position": 3,
         "item": {
-          "@id": "/issues/46",
+          "@id": "https://example.com/issues/46",
           "name": "My Issue"
         }
       }
@@ -118,6 +119,18 @@ Option                   | Description                                          
 Options concerned only with HTML presentation do not change the JSON-LD output. For example, `link_current` only controls whether the current crumb is rendered as an HTML link. The current crumb always includes `item.@id` in JSON-LD.
 
 For further information, please see [Gretel's documentation](https://github.com/kzkn/gretel#options).
+
+## Nice to know
+
+### Breadcrumb URLs
+
+Relative breadcrumb paths are resolved against the current request's base URL.
+Absolute breadcrumb URLs are used as-is.
+
+Breadcrumbs without link URLs are omitted from the JSON-LD output because each
+breadcrumb item is identified by `@id`, whose value must be an IRI reference
+under the
+[JSON-LD specification](https://www.w3.org/TR/json-ld11/#node-objects).
 
 ## Supported versions
 

--- a/lib/gretel/jsonld/breadcrumb/list.rb
+++ b/lib/gretel/jsonld/breadcrumb/list.rb
@@ -1,34 +1,21 @@
 # frozen_string_literal: true
 
 require "json"
-require "gretel/jsonld/breadcrumb/list_item"
 
 module Gretel
   module JSONLD
     module Breadcrumb
       class List
-        def initialize(link_collection)
-          @link_collection = link_collection
+        def initialize(items)
+          @items = items
         end
 
         def to_json(*args)
           {
             "@context": "http://schema.org",
             "@type": "BreadcrumbList",
-            itemListElement: item_list_element
+            itemListElement: @items
           }.to_json(*args)
-        end
-
-        private
-
-        def item_list_element
-          @link_collection.map.with_index(1) do |link, index|
-            ::Gretel::JSONLD::Breadcrumb::ListItem.new(
-              id: link.url,
-              name: link.text,
-              position: index,
-            )
-          end
         end
       end
     end

--- a/lib/gretel/jsonld/breadcrumb/list_item.rb
+++ b/lib/gretel/jsonld/breadcrumb/list_item.rb
@@ -6,10 +6,10 @@ module Gretel
   module JSONLD
     module Breadcrumb
       class ListItem
-        def initialize(id:, name:, position:)
-          @id = id
-          @name = name
+        def initialize(position:, title:, url:)
           @position = position
+          @title = title
+          @url = url
         end
 
         def to_json(*args)
@@ -17,8 +17,8 @@ module Gretel
             "@type": "ListItem",
             position: @position,
             item: {
-              "@id": @id,
-              name: @name
+              "@id": @url,
+              name: @title
             }
           }.to_json(*args)
         end

--- a/lib/gretel/jsonld/renderer.rb
+++ b/lib/gretel/jsonld/renderer.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-require "json"
 require "active_support"
 require "active_support/core_ext/string/output_safety"
+require "json"
 require "gretel/jsonld/breadcrumb/list"
+require "gretel/jsonld/breadcrumb/list_item"
+require "uri"
 
 module Gretel
   module JSONLD
@@ -17,9 +19,27 @@ module Gretel
 
         @view_context.content_tag(
           :script,
-          JSON.generate(::Gretel::JSONLD::Breadcrumb::List.new(link_collection)).html_safe,
+          JSON.generate(to_breadcrumb_list(link_collection)).html_safe,
           type: "application/ld+json",
         )
+      end
+
+      private
+
+      def resolve_uri(uri_reference)
+        ::URI.join(@view_context.request.base_url, uri_reference)
+      end
+
+      def to_breadcrumb_list(link_collection)
+        link_collection
+          .select { |link, _| link.url }
+          .map.with_index(1) { |link, position|
+            ::Gretel::JSONLD::Breadcrumb::ListItem.new(
+              position: position,
+              title: link.text,
+              url: resolve_uri(link.url),
+            )
+          }.yield_self { |items| ::Gretel::JSONLD::Breadcrumb::List.new(items) }
       end
     end
   end

--- a/spec/dummy/config/breadcrumbs.rb
+++ b/spec/dummy/config/breadcrumbs.rb
@@ -2,6 +2,11 @@ crumb :root do
   link "Home", root_url
 end
 
+crumb :without_link do
+  link "Breadcrumb without link"
+end
+
 crumb :with_root do
-  link "About", about_url
+  link "About", about_path(foo: 'bar')
+  parent :without_link
 end

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
               "@type": "ListItem",
               position: 2,
               item: {
-                "@id": "http://test.host/about",
+                "@id": "http://test.host/about?foo=bar",
                 name: "About"
               }
             }
@@ -67,7 +67,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
                   "@type": "ListItem",
                   position: 1,
                   item: {
-                    "@id": "http://test.host/about",
+                    "@id": "http://test.host/about?foo=bar",
                     name: "About"
                   }
                 }
@@ -127,8 +127,6 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
         context "when set to true" do
           let(:link_current_to_request_path) { true }
 
-          # TODO: Convert this relative request path to an absolute URL. Google reports
-          # it as a non-critical `Invalid URL in field "id"` issue.
           let(:expectation) do
             {
               "@context": "http://schema.org",
@@ -146,7 +144,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
                   "@type": "ListItem",
                   position: 2,
                   item: {
-                    "@id": "/requested",
+                    "@id": "http://test.host/requested",
                     name: "About"
                   }
                 }


### PR DESCRIPTION
## Summary

- Resolve relative breadcrumb paths against the current request's base URL while preserving absolute URLs.
- Omit Gretel breadcrumbs without link URLs and renumber the remaining `ListItem` entries.
- Document URL handling and update the JSON-LD example to use absolute item identifiers.
- Change the internal `Breadcrumb::List` and `Breadcrumb::ListItem` initializer contracts.

## Why

[Schema.org defines a `BreadcrumbList`](https://schema.org/BreadcrumbList) as a chain of linked web pages, and its JSON-LD example identifies each `ListItem` page with `item.@id`.

Previously, `Breadcrumb::List` converted the Gretel link collection without access to the current request. Relative paths therefore remained relative, and breadcrumbs without link URLs produced missing item identifiers. Moving that conversion into `Renderer` provides the request context needed to resolve paths and omit entries that cannot identify a linked page.

## Breaking internal API changes

The initializer contracts of the internal JSON-LD classes have changed:

- `Gretel::JSONLD::Breadcrumb::List` now accepts rendered `ListItem` objects instead of a Gretel `LinkCollection`.
- `Gretel::JSONLD::Breadcrumb::ListItem` replaces the `id:` and `name:` keyword arguments with `url:` and `title:`.

These classes are not documented as public APIs, but callers that instantiate them directly must update their code. This is therefore a breaking change for consumers of these internal APIs.

## Validation

- `bundle exec rspec` — 8 examples, 0 failures