### PR TITLE
Fix development binstubs

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "rails"
 require "gretel/jsonld"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/bin/test
+++ b/bin/test
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-$: << File.expand_path(File.expand_path("../../test", __FILE__))
-
-require "bundler/setup"
-require "rails/plugin/test"


### PR DESCRIPTION
## Summary

- Load Rails before Gretel in `bin/console`.
- Remove the broken, unused `bin/test` entry point in favor of `bundle exec rake`.

## Why

Gretel 5 loads its Railtie while the gem is required and expects the `Rails` constant to already exist. As a result, `bin/console` raised a `NameError` before the console could start.

`bin/test` also no longer provides a working entry point and is not used by the project workflow. The test suite is already available through `bundle exec rake`, so keeping the broken alternative is misleading.

## Impact

The development console starts with the current Gretel dependency, and the repository exposes a single working command for running the test suite.

## Validation

- `./bin/console </dev/null`
- `bundle exec rake` (8 examples, 0 failures)