### PR TITLE
Prepare v1.0.0.rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,28 @@
 # CHANGELOG
+
+## [1.0.0.rc1](https://github.com/yasaichi/gretel-jsonld/releases/tag/v1.0.0.rc1) (July 23, 2026)
+
+* [Generate valid breadcrumb item URLs](https://github.com/yasaichi/gretel-jsonld/pull/28)
+* [Document effective Gretel options](https://github.com/yasaichi/gretel-jsonld/pull/27)
+* [Load Railtie only when available](https://github.com/yasaichi/gretel-jsonld/pull/24)
+* [Specify minimum Rails dependencies](https://github.com/yasaichi/gretel-jsonld/pull/21)
+* [Support Gretel 4 and 5](https://github.com/yasaichi/gretel-jsonld/pull/19)
+
 ## [0.3.0](https://github.com/yasaichi/gretel-jsonld/releases/tag/v0.3.0) (July 22, 2026)
+
 * [Test against Rails 6 through 8](https://github.com/yasaichi/gretel-jsonld/pull/18)
 * [Drop support for Ruby 2.4 and earlier](https://github.com/yasaichi/gretel-jsonld/pull/16)
 
 ## [0.2.0](https://github.com/yasaichi/gretel-jsonld/releases/tag/v0.2.0) (November 25, 2017)
+
 * [Write README](https://github.com/yasaichi/gretel-jsonld/pull/7)
 * [Use `JSONLD` as module name instead of `Jsonld`](https://github.com/yasaichi/gretel-jsonld/pull/6)
 * [Specify the required Ruby version](https://github.com/yasaichi/gretel-jsonld/pull/5)
 
 ## [0.1.1](https://github.com/yasaichi/gretel-jsonld/releases/tag/v0.1.1) (November 25, 2017)
+
 * [Cope with Rails 4.0 or former](https://github.com/yasaichi/gretel-jsonld/pull/4)
 
 ## [0.1.0](https://github.com/yasaichi/gretel-jsonld/releases/tag/v0.1.0) (November 23, 2017)
+
 * The initial release to reserve the gem name

--- a/README.md
+++ b/README.md
@@ -4,43 +4,42 @@
 [![CI](https://github.com/yasaichi/gretel-jsonld/actions/workflows/ci.yml/badge.svg)](https://github.com/yasaichi/gretel-jsonld/actions/workflows/ci.yml)
 [![Code Coverage](https://qlty.sh/gh/yasaichi/projects/gretel-jsonld/coverage.svg)](https://qlty.sh/gh/yasaichi/projects/gretel-jsonld)
 
-gretel-jsonld enables gretel gem to handle JSON-LD based breadcrumbs.
+gretel-jsonld enables [gretel](https://github.com/kzkn/gretel) to generate
+breadcrumbs using JSON-LD structured data.
 
 ## Installation
 
-Add this line to your application's `Gemfile`:
+In your `Gemfile`:
 
 ```ruby
-gem 'gretel-jsonld'
+gem "gretel-jsonld"
 ```
 
-And then execute:
+And run:
 
 ```bash
-$ bundle
+$ bundle install
 ```
 
-## Usage
+## Example
 
-First, run the installation generator with:
+Start by generating the breadcrumbs configuration file:
 
 ```sh
 $ rails generate gretel:install
 ```
 
-Next, define "crumbs" in `config/breadcrumbs.rb`:
+Then, in `config/breadcrumbs.rb`:
 
 ```ruby
-# See also: https://github.com/kzkn/gretel#more-examples
-
 # Root crumb
 crumb :root do
-  link 'Home', root_path
+  link "Home", root_path
 end
 
 # Issue list
 crumb :issues do
-  link 'All issues', issues_path
+  link "All issues", issues_path
 end
 
 # Issue
@@ -50,16 +49,17 @@ crumb :issue do |issue|
 end
 ```
 
-Then, add this line to your application's layout:
-
-```erb
-<%= jsonld_breadcrumbs %>
-```
-
-Finally, specify a current breadcrumb in each view:
+At the top of `app/views/issues/show.html.erb`, set the current breadcrumb
+(assuming you have loaded `@issue` with an issue):
 
 ```erb
 <% breadcrumb :issue, @issue %>
+```
+
+Then, in `app/views/layouts/application.html.erb`:
+
+```erb
+<%= jsonld_breadcrumbs %>
 ```
 
 For a request to `https://example.com/issues/46`, this will generate the
@@ -102,13 +102,13 @@ following JSON-LD (indented for readability):
 
 ## Options
 
-You can pass `jsonld_breadcrumbs` the same options as `breadcrumbs`.
+You can pass options to `<%= jsonld_breadcrumbs %>`, e.g.:
 
 ```erb
 <%= jsonld_breadcrumbs autoroot: false, link_current_to_request_path: false %>
 ```
 
-Options that change the breadcrumb collection also affect the JSON-LD output. The following options directly affect the output:
+Options that change the breadcrumb collection also affect the JSON-LD output:
 
 Option                   | Description                                                                                                                 | Default
 ------------------------ | --------------------------------------------------------------------------------------------------------------------------- | -------
@@ -116,9 +116,13 @@ Option                   | Description                                          
 :display_single_fragment | Whether it should output the `BreadcrumbList` if it includes only one item.                                                  | False
 :link_current_to_request_path | Whether the current crumb's `item.@id` in the `BreadcrumbList` should always use the current request path.                    | True
 
-Options concerned only with HTML presentation do not change the JSON-LD output. For example, `link_current` only controls whether the current crumb is rendered as an HTML link. The current crumb always includes `item.@id` in JSON-LD.
+Options concerned only with HTML presentation do not change the JSON-LD
+output. For example, `link_current` controls whether the current crumb is
+rendered as an HTML link, but the current crumb always includes `item.@id` in
+JSON-LD.
 
-For further information, please see [Gretel's documentation](https://github.com/kzkn/gretel#options).
+For further information, please see
+[Gretel's documentation](https://github.com/kzkn/gretel#options).
 
 ## Nice to know
 
@@ -143,11 +147,11 @@ The supported version ranges are:
 | 4.x | 5.1 through 7.1 | 2.5 or later |
 | 5.x | 6.1 or later | 3.0 or later |
 
-CI tests the latest releases in the lowest and current highest Rails majors for each gretel major.
+CI covers the lowest and highest supported Rails majors for each gretel major.
 
 ## Contributing
 
-You should follow the steps below:
+To contribute:
 
 1. [Fork the repository](https://help.github.com/articles/fork-a-repo/)
 2. Create a feature branch: `git checkout -b add-new-feature`

--- a/lib/gretel/jsonld/version.rb
+++ b/lib/gretel/jsonld/version.rb
@@ -2,6 +2,6 @@
 
 module Gretel
   module JSONLD
-    VERSION = "0.3.0".freeze
+    VERSION = "1.0.0.rc1".freeze
   end
 end


### PR DESCRIPTION
## Summary

- Bump the gem version from `0.3.0` to `1.0.0.rc1`.
- Add the `1.0.0.rc1` changelog entry for application, runtime dependency, and test-related changes since `v0.3.0`.
- Update the README installation, usage example, options, and support wording to match the current behavior.

## Why

The first 1.0 release candidate needs package metadata that RubyGems recognizes as a prerelease and documentation that reflects the current integration. Keeping the version, changelog, and usage guide together ensures the published gem and its release information agree.

## Impact

RubyGems identifies the built artifact as the `1.0.0.rc1` prerelease. Users testing the release candidate have an up-to-date setup sequence and a focused summary of changes since `v0.3.0`.

## Validation

- `bundle exec rake` (8 examples, 0 failures)
- `gem build gretel-jsonld.gemspec` (`gretel-jsonld-1.0.0.rc1.gem`, recognized as a prerelease)