### PR TITLE
Clean up project configuration

### DIFF
--- a/.reek
+++ b/.reek
@@ -1,8 +1,0 @@
-Attribute:
-  enabled: false
-IrresponsibleModule:
-  enabled: false
-NestedIterators:
-  max_allowed_nesting: 2
-TooManyStatements:
-  max_statements: 10

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,9 @@
+detectors:
+  Attribute:
+    enabled: false
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    max_allowed_nesting: 2
+  TooManyStatements:
+    max_statements: 10

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
-end
+require "bundler/gem_tasks"
 
 require "rdoc/task"
 
@@ -19,5 +15,3 @@ end
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 task default: :spec
-
-require "bundler/gem_tasks"

--- a/gretel-jsonld.gemspec
+++ b/gretel-jsonld.gemspec
@@ -1,7 +1,5 @@
-$:.push File.expand_path("../lib", __FILE__)
-
 # Maintain your gem's version:
-require "gretel/jsonld/version"
+require_relative "lib/gretel/jsonld/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|

--- a/lib/gretel/jsonld/renderer.rb
+++ b/lib/gretel/jsonld/renderer.rb
@@ -19,7 +19,7 @@ module Gretel
 
         @view_context.content_tag(
           :script,
-          JSON.generate(to_breadcrumb_list(link_collection)).html_safe,
+          ::JSON.generate(to_breadcrumb_list(link_collection)).html_safe,
           type: "application/ld+json",
         )
       end
@@ -30,9 +30,10 @@ module Gretel
         ::URI.join(@view_context.request.base_url, uri_reference)
       end
 
+      # :reek:FeatureEnvy
       def to_breadcrumb_list(link_collection)
         link_collection
-          .select { |link, _| link.url }
+          .select(&:url)
           .map.with_index(1) { |link, position|
             ::Gretel::JSONLD::Breadcrumb::ListItem.new(
               position: position,

--- a/lib/gretel/jsonld/version.rb
+++ b/lib/gretel/jsonld/version.rb
@@ -2,6 +2,6 @@
 
 module Gretel
   module JSONLD
-    VERSION = "1.0.0.rc1".freeze
+    VERSION = "1.0.0.rc1"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
-require File.expand_path("../dummy/config/environment", __FILE__)
+require_relative "dummy/config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"


### PR DESCRIPTION
## Summary

- update the Reek configuration for Reek 6.5 and keep the intentional renderer mapping suppression local to the method
- align gem task loading with the Rakefile generated by current Bundler
- use relative requires for repository-owned files and remove a redundant version string freeze

## Why

The legacy Reek filename and schema were silently ignored, while several project files retained patterns generated for older Ruby and Bundler versions. These small cleanups make the development checks effective and keep local file loading explicit without changing the gem's behavior.

## Verification

- `bundle exec reek .`
- `bundle exec rubocop --cache false`
- `bundle exec rake`
- `bundle exec rake build`
