### PR TITLE
Use HTTPS for Schema.org context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ following JSON-LD (indented for readability):
 ```html
 <script type="application/ld+json">
   {
-    "@context": "http://schema.org",
+    "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
       {

--- a/lib/gretel/jsonld/breadcrumb/list.rb
+++ b/lib/gretel/jsonld/breadcrumb/list.rb
@@ -12,7 +12,7 @@ module Gretel
 
         def to_json(*args)
           {
-            "@context": "http://schema.org",
+            "@context": "https://schema.org",
             "@type": "BreadcrumbList",
             itemListElement: @items
           }.to_json(*args)

--- a/spec/lib/gretel/jsonld/view_helpers_spec.rb
+++ b/spec/lib/gretel/jsonld/view_helpers_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
     context "when #breadcrumb is called in advance" do
       let(:full_list) do
         {
-          "@context": "http://schema.org",
+          "@context": "https://schema.org",
           "@type": "BreadcrumbList",
           itemListElement: [
             {
@@ -60,7 +60,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
           let(:autoroot) { false }
           let(:expectation) do
             {
-              "@context": "http://schema.org",
+              "@context": "https://schema.org",
               "@type": "BreadcrumbList",
               itemListElement: [
                 {
@@ -92,7 +92,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
           let(:display_single_fragment) { true }
           let(:expectation) do
             {
-              "@context": "http://schema.org",
+              "@context": "https://schema.org",
               "@type": "BreadcrumbList",
               itemListElement: [
                 {
@@ -129,7 +129,7 @@ RSpec.describe Gretel::JSONLD::ViewHelpers, type: :helper do
 
           let(:expectation) do
             {
-              "@context": "http://schema.org",
+              "@context": "https://schema.org",
               "@type": "BreadcrumbList",
               itemListElement: [
                 {


### PR DESCRIPTION
## Summary

- Change generated breadcrumb JSON-LD to use `https://schema.org` as its `@context`
- Update the RSpec expectations and README example to match

## Why

The gem still emitted the legacy HTTP Schema.org context. Schema.org's [FAQ on choosing HTTP or HTTPS](https://schema.org/docs/faq.html) says both forms are valid, while HTTPS is the site's default and preferred form in examples. Using HTTPS aligns generated breadcrumbs with that preference.

## Impact

Only the JSON-LD `@context` value changes. Breadcrumb structure and item URLs remain unchanged.

## Verification

- `direnv exec . bundle exec rake` (8 examples, 0 failures)
- `git diff --check`