### PR TITLE
Prepare v1.0.0.rc2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.0.0.rc2](https://github.com/yasaichi/gretel-jsonld/releases/tag/v1.0.0.rc2) (July 24, 2026)
+
+* [Use HTTPS for Schema.org context](https://github.com/yasaichi/gretel-jsonld/pull/32)
+
 ## [1.0.0.rc1](https://github.com/yasaichi/gretel-jsonld/releases/tag/v1.0.0.rc1) (July 23, 2026)
 
 * [Generate valid breadcrumb item URLs](https://github.com/yasaichi/gretel-jsonld/pull/28)

--- a/lib/gretel/jsonld/version.rb
+++ b/lib/gretel/jsonld/version.rb
@@ -2,6 +2,6 @@
 
 module Gretel
   module JSONLD
-    VERSION = "1.0.0.rc1"
+    VERSION = "1.0.0.rc2"
   end
 end


### PR DESCRIPTION
## Summary

- Bump the gem version from `1.0.0.rc1` to `1.0.0.rc2`
- Add the HTTPS Schema.org context change to the changelog

## Why

This release candidate makes the only user-facing change since rc1 available for validation before the final 1.0.0 release.

## Impact

The built gem is now versioned as `1.0.0.rc2`. The changelog includes the generated JSON-LD context change from PR #32.

## Verification

- `bundle exec rake` (8 examples, 0 failures)
- `bundle exec rake build` (`gretel-jsonld-1.0.0.rc2.gem` built successfully)
- Confirmed `1.0.0.rc2` is a valid RubyGems prerelease version and sorts before `1.0.0`
- `git diff --check`